### PR TITLE
Fix PHP notice warning message

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -174,7 +174,7 @@ class Container {
 	}
 
 	public function getFragment($name) {
-		return @$this->fragments[$name];
+		return $this->fragments[$name] ?? null;
 	}
 
     /**

--- a/src/Query.php
+++ b/src/Query.php
@@ -100,7 +100,7 @@ class Query extends Container {
      * @return FragmentDefinitionContainer
      */
 	public function getFragmentDefinition($name) {
-		return @$this->fragmentDefinitions[$name];
+		return $this->fragmentDefinitions[$name] ?? null;
 	}
 
 	static public function enum($name) {


### PR DESCRIPTION
Fix the key didn't in the `fragmentDefinitions`, and show the warning message

```php
$this->query->fields('websitePages');
$this->query->websitePages->fields(
    'name',
    'slug',
    'contents'
);
```

<img width="361" alt="php-notice-warning-message" src="https://user-images.githubusercontent.com/5094008/49323914-3b92af80-f55e-11e8-98aa-2d6f26d258b2.png">
